### PR TITLE
Feat/#5 extract colors

### DIFF
--- a/PaletteM/PaletteM.xcodeproj/project.pbxproj
+++ b/PaletteM/PaletteM.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		AF8F62732C9163CF00D6E8E2 /* DetectedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62722C9163CF00D6E8E2 /* DetectedObject.swift */; };
 		AF8F62752C9165EA00D6E8E2 /* ObjectDetectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62742C9165EA00D6E8E2 /* ObjectDetectionManager.swift */; };
 		AF8F62772C93C27D00D6E8E2 /* YOLOv3Int8LUT.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62762C93C27D00D6E8E2 /* YOLOv3Int8LUT.mlmodel */; };
+		AF8F62792C95E35900D6E8E2 /* ColorExtractionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62782C95E35900D6E8E2 /* ColorExtractionManager.swift */; };
+		AF8F627C2C95E3C500D6E8E2 /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F627B2C95E3C500D6E8E2 /* UIImage+Extensions.swift */; };
+		AF8F627E2C95EA1B00D6E8E2 /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F627D2C95EA1B00D6E8E2 /* Color+Extensions.swift */; };
+		AF8F62802C95EAA500D6E8E2 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F627F2C95EAA500D6E8E2 /* UIColor+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +31,10 @@
 		AF8F62722C9163CF00D6E8E2 /* DetectedObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectedObject.swift; sourceTree = "<group>"; };
 		AF8F62742C9165EA00D6E8E2 /* ObjectDetectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectDetectionManager.swift; sourceTree = "<group>"; };
 		AF8F62762C93C27D00D6E8E2 /* YOLOv3Int8LUT.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = YOLOv3Int8LUT.mlmodel; sourceTree = "<group>"; };
+		AF8F62782C95E35900D6E8E2 /* ColorExtractionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtractionManager.swift; sourceTree = "<group>"; };
+		AF8F627B2C95E3C500D6E8E2 /* UIImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extensions.swift"; sourceTree = "<group>"; };
+		AF8F627D2C95EA1B00D6E8E2 /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
+		AF8F627F2C95EAA500D6E8E2 /* UIColor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +81,7 @@
 		AF8F62672C91524300D6E8E2 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				AF8F627A2C95E39000D6E8E2 /* Helper */,
 				AF8F626E2C91544300D6E8E2 /* ColorInfo.swift */,
 				AF8F62722C9163CF00D6E8E2 /* DetectedObject.swift */,
 			);
@@ -99,8 +108,19 @@
 			isa = PBXGroup;
 			children = (
 				AF8F62742C9165EA00D6E8E2 /* ObjectDetectionManager.swift */,
+				AF8F62782C95E35900D6E8E2 /* ColorExtractionManager.swift */,
 			);
 			path = Manager;
+			sourceTree = "<group>";
+		};
+		AF8F627A2C95E39000D6E8E2 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				AF8F627B2C95E3C500D6E8E2 /* UIImage+Extensions.swift */,
+				AF8F627D2C95EA1B00D6E8E2 /* Color+Extensions.swift */,
+				AF8F627F2C95EAA500D6E8E2 /* UIColor+Extensions.swift */,
+			);
+			path = Helper;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -174,9 +194,13 @@
 			files = (
 				AF8F62752C9165EA00D6E8E2 /* ObjectDetectionManager.swift in Sources */,
 				AF8F626F2C91544300D6E8E2 /* ColorInfo.swift in Sources */,
+				AF8F62792C95E35900D6E8E2 /* ColorExtractionManager.swift in Sources */,
 				AF8F625C2C9135AA00D6E8E2 /* ContentView.swift in Sources */,
 				AF8F625A2C9135AA00D6E8E2 /* PaletteMApp.swift in Sources */,
+				AF8F627E2C95EA1B00D6E8E2 /* Color+Extensions.swift in Sources */,
 				AF8F62772C93C27D00D6E8E2 /* YOLOv3Int8LUT.mlmodel in Sources */,
+				AF8F62802C95EAA500D6E8E2 /* UIColor+Extensions.swift in Sources */,
+				AF8F627C2C95E3C500D6E8E2 /* UIImage+Extensions.swift in Sources */,
 				AF8F62732C9163CF00D6E8E2 /* DetectedObject.swift in Sources */,
 				AF8F62712C91551700D6E8E2 /* ColorExtractorViewModel.swift in Sources */,
 			);

--- a/PaletteM/PaletteM/Manager/ColorExtractionManager.swift
+++ b/PaletteM/PaletteM/Manager/ColorExtractionManager.swift
@@ -1,0 +1,226 @@
+//
+//  ColorExtractionManager.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/15/24.
+//
+
+import UIKit
+import SwiftUI
+
+class ColorExtractionManager {
+    
+    static let shared = ColorExtractionManager()
+    private init(){}
+    class ColorExtractionManager {
+        
+        /// 원하는 비트 수 (예: 4비트)
+        let bitsPerChannel: UInt8 = 4
+        
+        /// 이미지에서 색상을 추출하고 가중치를 적용하여 정렬한 색상 정보를 반환합니다.
+        func extractColors(from image: UIImage, detectedObjects: [DetectedObject], labelWeights: [String: Double]) -> [ColorInfo] {
+            
+            guard let pixelData = image.pixelData(), let cgImage = image.cgImage else {
+                return []
+            }
+            
+            let width = Int(cgImage.width)
+            let height = Int(cgImage.height)
+            let bytesPerPixel = 4
+            let bytesPerRow = bytesPerPixel * width
+            
+            var colorCounts: [UInt32: Double] = [:] // 색상 키와 가중치가 적용된 카운트
+            
+            // 바운딩 박스와 label 별 가중치를 준비합니다.
+            var boxesWithWeights: [(box: CGRect, weight: Double)] = []
+            for object in detectedObjects {
+                let label = object.label
+                let weight = labelWeights[label] ?? 1.2 // 해당 레이블의 가중치, 기본값은 1.2
+                boxesWithWeights.append((box: object.boundingBox, weight: weight))
+            }
+            
+            // 각 채널에 대한 시프트 연산 계산
+            let shiftAmount = UInt8(8 - bitsPerChannel)
+            let maxChannelValue = UInt8((1 << bitsPerChannel) - 1)
+            
+            // 픽셀 데이터를 순회합니다.
+            for y in 0..<height {
+                for x in 0..<width {
+                    let pixelIndex = y * bytesPerRow + x * bytesPerPixel
+                    let r = pixelData[pixelIndex]
+                    let g = pixelData[pixelIndex + 1]
+                    let b = pixelData[pixelIndex + 2]
+                    let a = pixelData[pixelIndex + 3]
+                    
+                    // 투명한 픽셀은 건너뜁니다.
+                    if a == 0 { continue }
+                    
+                    // 색상 양자화 적용
+                    let quantizedR = (r >> shiftAmount) & maxChannelValue
+                    let quantizedG = (g >> shiftAmount) & maxChannelValue
+                    let quantizedB = (b >> shiftAmount) & maxChannelValue
+                    let quantizedA = (a >> shiftAmount) & maxChannelValue
+                    
+                    // UIColor 생성
+                    let color = UIColor(
+                        red: CGFloat(quantizedR) / CGFloat(maxChannelValue),
+                        green: CGFloat(quantizedG) / CGFloat(maxChannelValue),
+                        blue: CGFloat(quantizedB) / CGFloat(maxChannelValue),
+                        alpha: CGFloat(quantizedA) / CGFloat(maxChannelValue)
+                    )
+                    
+                    // 좌표 변환 (UIKit과 Core Graphics 좌표계 차이 보정)
+                    let adjustedY = height - y - 1
+                    let point = CGPoint(x: x, y: adjustedY)
+                    
+                    var maxWeight: Double = 1.0 // 기본 가중치
+                    
+                    // 모든 바운딩 박스를 확인하여 최대 가중치를 찾습니다.
+                    for (box, weight) in boxesWithWeights {
+                        if box.contains(point) {
+                            maxWeight = max(maxWeight, weight)
+                            // break를 사용하지 않으므로 모든 바운딩 박스를 검사합니다.
+                        }
+                    }
+                    
+                    // **채도 계산 및 가중치 조정**
+                    let saturation = color.saturation
+                    let saturationWeight = Double(saturation)
+                    
+                    // 채도가 낮은 색상에 대한 가중치를 낮춤
+                    maxWeight *= saturationWeight
+                    
+                    // 색상을 키로 만듭니다.
+                    let colorKey = color.quantizedColorKey(bitsPerChannel: bitsPerChannel)
+                    
+                    // 색상 카운트에 가중치를 적용합니다.
+                    colorCounts[colorKey, default: 0.0] += maxWeight
+                }
+            }
+            
+            // 전체 가중치 합계를 계산합니다.
+            let totalWeightedCounts = colorCounts.values.reduce(0, +)
+            var colorInfos: [ColorInfo] = []
+            
+            // 각 색상의 퍼센티지를 계산하고 `ColorInfo` 배열을 생성합니다.
+            for (colorKey, count) in colorCounts {
+                let percentage = (count / totalWeightedCounts) * 100
+                
+                // 양자화된 색상을 원래 범위로 변환
+                let quantizedR = UInt8((colorKey >> 24) & 0xFF)
+                let quantizedG = UInt8((colorKey >> 16) & 0xFF)
+                let quantizedB = UInt8((colorKey >> 8) & 0xFF)
+                let quantizedA = UInt8(colorKey & 0xFF)
+                
+                // 원래 색상 범위로 복원
+                let r = CGFloat(quantizedR) / CGFloat(maxChannelValue)
+                let g = CGFloat(quantizedG) / CGFloat(maxChannelValue)
+                let b = CGFloat(quantizedB) / CGFloat(maxChannelValue)
+                let a = CGFloat(quantizedA) / CGFloat(maxChannelValue)
+                
+                let color = Color(red: r, green: g, blue: b, opacity: a)
+                colorInfos.append(ColorInfo(color: color, percentage: percentage))
+            }
+            
+            // 퍼센티지에 따라 내림차순으로 정렬합니다.
+            colorInfos.sort { $0.percentage > $1.percentage }
+            
+            return colorInfos
+        }
+        
+        /// RGB 값이 흰색 또는 검은색인지 판단하는 메서드
+        private func isBlackOrWhite(r: UInt8, g: UInt8, b: UInt8) -> Bool {
+            // 흰색과 검은색을 판단하는 임계값 설정 (양자화된 값 기준)
+            let threshold: UInt8 = 2 // 필요에 따라 조정
+            let maxChannelValue = UInt8((1 << bitsPerChannel) - 1)
+            
+            let isBlack = r < threshold && g < threshold && b < threshold
+            let isWhite = r > (maxChannelValue - threshold) && g > (maxChannelValue - threshold) && b > (maxChannelValue - threshold)
+            
+            return isBlack || isWhite
+        }
+        
+ 
+        /// 정렬된 색상 리스트에서 빈도와 거리를 고려하여 색상을 선택하는 메서드
+        func selectDistinctColors(from colors: [ColorInfo], count: Int = 5, distanceThreshold: Double = 80.0, frequencyThreshold: Double = 0.2) -> [ColorInfo] {
+            guard !colors.isEmpty else { return [] }
+            
+            // 빈도 임계값 이상인 색상만 필터링
+            var filteredColors = colors.filter { $0.percentage >= frequencyThreshold }
+            
+            // 빈도 임계값을 만족하는 색상이 없으면 임계값을 낮춤
+            var frequencyThreshold = frequencyThreshold
+            while filteredColors.isEmpty && frequencyThreshold > 0 {
+                frequencyThreshold -= 0.5
+                filteredColors = colors.filter { $0.percentage >= frequencyThreshold }
+            }
+            
+            // 선택된 색상을 저장할 배열
+            var selectedColors: [ColorInfo] = []
+            
+            // 첫 번째로 빈도가 높은 색상을 추가
+            if let firstColor = filteredColors.first {
+                selectedColors.append(firstColor)
+            }
+            
+            // 거리 임계값을 동적으로 조정
+            var distanceThreshold = distanceThreshold
+            
+            while selectedColors.count < count && distanceThreshold > 0 {
+                for colorInfo in filteredColors {
+                    // 이미 선택된 색상은 건너뜀
+                    if selectedColors.contains(where: { $0.color == colorInfo.color }) {
+                        continue
+                    }
+                    
+                    // 이미 선택된 색상들과의 최소 거리 계산
+                    let minDistance = selectedColors.map { self.colorDistanceLab($0.color, colorInfo.color) }.min() ?? 0
+                    
+                    // 거리 임계값 이상이면 선택
+                    if minDistance >= distanceThreshold {
+                        selectedColors.append(colorInfo)
+                        if selectedColors.count >= count {
+                            break
+                        }
+                    }
+                }
+                
+                // 선택된 색상 수가 부족하면 거리 임계값을 낮춤
+                distanceThreshold -= 5.0
+            }
+            
+            // 여전히 선택된 색상 수가 부족하면 빈도가 높은 순서대로 추가
+            if selectedColors.count < count {
+                for colorInfo in filteredColors {
+                    if selectedColors.contains(where: { $0.color == colorInfo.color }) {
+                        continue
+                    }
+                    selectedColors.append(colorInfo)
+                    if selectedColors.count >= count {
+                        break
+                    }
+                }
+            }
+            
+            return selectedColors
+        }
+        
+        /// 두 색상 간의 Lab 색상 공간에서의 거리 계산
+        private func colorDistanceLab(_ color1: Color, _ color2: Color) -> Double {
+            // Color를 UIColor로 변환
+            let uiColor1 = UIColor(color1)
+            let uiColor2 = UIColor(color2)
+            
+            // UIColor를 Lab 값으로 변환
+            let lab1 = uiColor1.toLab()
+            let lab2 = uiColor2.toLab()
+            
+            // 유클리드 거리 계산
+            let deltaL = lab1.L - lab2.L
+            let deltaA = lab1.a - lab2.a
+            let deltaB = lab1.b - lab2.b
+            
+            return sqrt(deltaL * deltaL + deltaA * deltaA + deltaB * deltaB)
+        }
+    }
+}

--- a/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
+++ b/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  Color+Extensions.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/15/24.
+//
+
+import SwiftUI
+
+extension Color {
+    /// Color를 UIColor로 변환
+    init(_ uiColor: UIColor) {
+        self.init(uiColor)
+    }
+}

--- a/PaletteM/PaletteM/Model/Helper/UIColor+Extensions.swift
+++ b/PaletteM/PaletteM/Model/Helper/UIColor+Extensions.swift
@@ -1,0 +1,78 @@
+//
+//  UIColor.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/15/24.
+//
+
+import SwiftUI
+
+extension UIColor {
+    /// UIColor를 Lab 색상 공간으로 변환
+    func toLab() -> (L: Double, a: Double, b: Double) {
+        // sRGB에서 XYZ로 변환
+        var r = Double(self.cgColor.components?[0] ?? 0)
+        var g = Double(self.cgColor.components?[1] ?? 0)
+        var blue = Double(self.cgColor.components?[2] ?? 0)
+        
+        // 선형화
+        r = r > 0.04045 ? pow((r + 0.055) / 1.055, 2.4) : r / 12.92
+        g = g > 0.04045 ? pow((g + 0.055) / 1.055, 2.4) : g / 12.92
+        blue = blue > 0.04045 ? pow((blue + 0.055) / 1.055, 2.4) : blue / 12.92
+        
+        // XYZ 변환
+        let X = (r * 0.4124 + g * 0.3576 + blue * 0.1805) / 0.95047
+        let Y = (r * 0.2126 + g * 0.7152 + blue * 0.0722) / 1.00000
+        let Z = (r * 0.0193 + g * 0.1192 + blue * 0.9505) / 1.08883
+        
+        // XYZ에서 Lab로 변환
+        func f(_ t: Double) -> Double {
+            return t > 0.008856 ? pow(t, 1.0/3.0) : (7.787 * t) + (16.0 / 116.0)
+        }
+        
+        let fx = f(X)
+        let fy = f(Y)
+        let fz = f(Z)
+        
+        let labL = (116 * fy) - 16
+        let labA = 500 * (fx - fy)
+        let labB = 200 * (fy - fz)
+        
+        return (L: labL, a: labA, b: labB)
+    }
+    
+    /// UIColor의 채도(Saturation)를 반환합니다.
+    var saturation: CGFloat {
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        
+        if self.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) {
+            return saturation
+        }
+        
+        return 0 // 기본값
+    }
+    
+    /// 양자화된 색상 키를 생성합니다.
+    func quantizedColorKey(bitsPerChannel: UInt8) -> UInt32 {
+        let maxChannelValue = CGFloat((1 << bitsPerChannel) - 1)
+        
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        
+        let quantizedR = UInt8(red * maxChannelValue)
+        let quantizedG = UInt8(green * maxChannelValue)
+        let quantizedB = UInt8(blue * maxChannelValue)
+        let quantizedA = UInt8(alpha * maxChannelValue)
+        
+        let colorKey = UInt32(quantizedR) << 24 | UInt32(quantizedG) << 16 | UInt32(quantizedB) << 8 | UInt32(quantizedA)
+        
+        return colorKey
+    }
+}

--- a/PaletteM/PaletteM/Model/Helper/UIImage+Extensions.swift
+++ b/PaletteM/PaletteM/Model/Helper/UIImage+Extensions.swift
@@ -1,0 +1,40 @@
+//
+//  UIImage+Extensions.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/15/24.
+//
+
+import SwiftUI
+
+extension UIImage {
+    func pixelData() -> [UInt8]? {
+        guard let cgImage = self.cgImage else { return nil }
+        
+        let width = Int(cgImage.width)
+        let height = Int(cgImage.height)
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel * width
+        let totalBytes = height * bytesPerRow
+        
+        var pixelData = [UInt8](repeating: 0, count: totalBytes)
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue // RGBA 순서
+        
+        guard let context = CGContext(
+            data: &pixelData,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else { return nil }
+        
+        let rect = CGRect(x: 0, y: 0, width: width, height: height)
+        context.draw(cgImage, in: rect)
+        
+        return pixelData
+    }
+}

--- a/PaletteM/PaletteM/View/ContentView.swift
+++ b/PaletteM/PaletteM/View/ContentView.swift
@@ -14,15 +14,15 @@ struct ContentView: View {
     
     var body: some View {
         VStack {
-            if let image = viewModel.selectedImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    
-            } else {
-                Text("선택한 이미지가 없습니다.")
-                    .frame(height: 200)
-            }
+//            if let image = viewModel.selectedImage {
+//                Image(uiImage: image)
+//                    .resizable()
+//                    .scaledToFit()
+//                    
+//            } else {
+//                Text("선택한 이미지가 없습니다.")
+//                    .frame(height: 200)
+//            }
             
             if let detectedImage = viewModel.imageWithDetectedObjects {
                 Image(uiImage: detectedImage)
@@ -41,7 +41,7 @@ struct ContentView: View {
                 // 여기서 샘플 이미지를 선택합니다.
                 // 실제 앱에서는 PHPickerViewController를 사용할 수 있습니다.
                 // 또는 camera를 이용해 사진을 찍는 로직
-                if let sampleImage = UIImage(named: "sample_person2") {
+                if let sampleImage = UIImage(named: "sample_dog1") {
                     viewModel.selectImage(sampleImage)
                 }
             }
@@ -56,6 +56,17 @@ struct ContentView: View {
                 ProgressView()
             } else {
                 List(viewModel.extractedColors) { colorInfo in
+                    HStack {
+                        Rectangle()
+                            .fill(colorInfo.color)
+                            .frame(width: 50, height: 50)
+                        Text("\(colorInfo.percentage, specifier: "%.1f")%")
+                    }
+                }
+                
+                Divider()
+                
+                List(viewModel.distinctColors) { colorInfo in
                     HStack {
                         Rectangle()
                             .fill(colorInfo.color)


### PR DESCRIPTION
## `ColorExtractionManager`
1. `extractColors` : 이미지에서 색상을 추출하여 빈도수 계산 및 가중치 조정 
- 색상 양자화를 적용하기 
- 객체 바운딩 박스 내부에 들어가는 픽셀값에 대해 가중치 적용 및 라벨에 따른 서로 다른 가중치 값 주기 
- 픽셀당 최대 가중치 값 하나만 적용 
- 흰색과 검은색 가중치 낮추기 

2. `selectDistinctColors` : 빈도 + 가중치가 고려된 색상 리스트에서 색 공간상에서의 거리를 고려하여 서로 다른 색상 선택
- `count` : 선택하고자하는 색상 갯수
- `distanceThreshold` : 색공간에서의 임계 거리 -> 해당 거리 만큼 차이가 나야만 선택 가능한 색상으로 취급
- `frequencyThreshold` : 출현 빈도가 해당 값 이상이 되어야 함 ( 임계거리 때문에 거의 등장하지 않는 색이 선택되는 것을 방지)


