### PR TITLE
Feat/#13 select image and save

### DIFF
--- a/PaletteM/PaletteM.xcodeproj/project.pbxproj
+++ b/PaletteM/PaletteM.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		AF8F62912C9707E500D6E8E2 /* ColorInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62902C9707E500D6E8E2 /* ColorInfoView.swift */; };
 		AF8F62932C97083C00D6E8E2 /* ColorInfoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62922C97083C00D6E8E2 /* ColorInfoCardView.swift */; };
 		AF8F62962C970E1F00D6E8E2 /* StackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62952C970E1F00D6E8E2 /* StackView.swift */; };
+		AF8F62982C97372500D6E8E2 /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62972C97372500D6E8E2 /* FloatingButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -49,6 +50,7 @@
 		AF8F62902C9707E500D6E8E2 /* ColorInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorInfoView.swift; sourceTree = "<group>"; };
 		AF8F62922C97083C00D6E8E2 /* ColorInfoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorInfoCardView.swift; sourceTree = "<group>"; };
 		AF8F62952C970E1F00D6E8E2 /* StackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackView.swift; sourceTree = "<group>"; };
+		AF8F62972C97372500D6E8E2 /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +166,7 @@
 				AF8F62832C96B0A900D6E8E2 /* PhotoFrameView.swift */,
 				AF8F62902C9707E500D6E8E2 /* ColorInfoView.swift */,
 				AF8F62922C97083C00D6E8E2 /* ColorInfoCardView.swift */,
+				AF8F62972C97372500D6E8E2 /* FloatingButton.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -255,6 +258,7 @@
 				AF8F628A2C96D31200D6E8E2 /* PreviewContainer.swift in Sources */,
 				AF8F628F2C97048C00D6E8E2 /* FlipCard.swift in Sources */,
 				AF8F62842C96B0A900D6E8E2 /* PhotoFrameView.swift in Sources */,
+				AF8F62982C97372500D6E8E2 /* FloatingButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PaletteM/PaletteM.xcodeproj/project.pbxproj
+++ b/PaletteM/PaletteM.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		AF8F62A42C97F67A00D6E8E2 /* GalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A32C97F67A00D6E8E2 /* GalleryView.swift */; };
 		AF8F62A62C98123600D6E8E2 /* ImageLoadingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A52C98123600D6E8E2 /* ImageLoadingService.swift */; };
 		AF8F62A82C98181E00D6E8E2 /* SelectedPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A72C98181E00D6E8E2 /* SelectedPhotoView.swift */; };
+		AF8F62AA2C981E2600D6E8E2 /* NavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A92C981E2600D6E8E2 /* NavigationDestination.swift */; };
+		AF8F62AC2C981F9100D6E8E2 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62AB2C981F9100D6E8E2 /* ResultView.swift */; };
+		AF8F62AE2C983ED500D6E8E2 /* LoadingFlipCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62AD2C983ED500D6E8E2 /* LoadingFlipCard.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +66,9 @@
 		AF8F62A32C97F67A00D6E8E2 /* GalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryView.swift; sourceTree = "<group>"; };
 		AF8F62A52C98123600D6E8E2 /* ImageLoadingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadingService.swift; sourceTree = "<group>"; };
 		AF8F62A72C98181E00D6E8E2 /* SelectedPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPhotoView.swift; sourceTree = "<group>"; };
+		AF8F62A92C981E2600D6E8E2 /* NavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDestination.swift; sourceTree = "<group>"; };
+		AF8F62AB2C981F9100D6E8E2 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		AF8F62AD2C983ED500D6E8E2 /* LoadingFlipCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingFlipCard.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +137,9 @@
 				AF8F62952C970E1F00D6E8E2 /* StackView.swift */,
 				AF8F628D2C97043500D6E8E2 /* Component */,
 				AF8F625B2C9135AA00D6E8E2 /* ContentView.swift */,
+				AF8F62A92C981E2600D6E8E2 /* NavigationDestination.swift */,
+				AF8F62AB2C981F9100D6E8E2 /* ResultView.swift */,
+				AF8F62AD2C983ED500D6E8E2 /* LoadingFlipCard.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -268,6 +277,7 @@
 			files = (
 				AF8F62752C9165EA00D6E8E2 /* ObjectDetectionManager.swift in Sources */,
 				AF8F62A02C97F32E00D6E8E2 /* GalleryViewModel.swift in Sources */,
+				AF8F62AC2C981F9100D6E8E2 /* ResultView.swift in Sources */,
 				AF8F626F2C91544300D6E8E2 /* ColorInfo.swift in Sources */,
 				AF8F62882C96CDF800D6E8E2 /* ImageData.swift in Sources */,
 				AF8F62792C95E35900D6E8E2 /* ColorExtractionManager.swift in Sources */,
@@ -280,6 +290,7 @@
 				AF8F62962C970E1F00D6E8E2 /* StackView.swift in Sources */,
 				AF8F62912C9707E500D6E8E2 /* ColorInfoView.swift in Sources */,
 				AF8F62A82C98181E00D6E8E2 /* SelectedPhotoView.swift in Sources */,
+				AF8F62AE2C983ED500D6E8E2 /* LoadingFlipCard.swift in Sources */,
 				AF8F62802C95EAA500D6E8E2 /* UIColor+Extensions.swift in Sources */,
 				AF8F627C2C95E3C500D6E8E2 /* UIImage+Extensions.swift in Sources */,
 				AF8F62732C9163CF00D6E8E2 /* DetectedObject.swift in Sources */,
@@ -288,6 +299,7 @@
 				AF8F62712C91551700D6E8E2 /* ColorExtractorViewModel.swift in Sources */,
 				AF8F628A2C96D31200D6E8E2 /* PreviewContainer.swift in Sources */,
 				AF8F628F2C97048C00D6E8E2 /* FlipCard.swift in Sources */,
+				AF8F62AA2C981E2600D6E8E2 /* NavigationDestination.swift in Sources */,
 				AF8F62842C96B0A900D6E8E2 /* PhotoFrameView.swift in Sources */,
 				AF8F62A62C98123600D6E8E2 /* ImageLoadingService.swift in Sources */,
 				AF8F62982C97372500D6E8E2 /* FloatingButton.swift in Sources */,

--- a/PaletteM/PaletteM.xcodeproj/project.pbxproj
+++ b/PaletteM/PaletteM.xcodeproj/project.pbxproj
@@ -27,6 +27,12 @@
 		AF8F62932C97083C00D6E8E2 /* ColorInfoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62922C97083C00D6E8E2 /* ColorInfoCardView.swift */; };
 		AF8F62962C970E1F00D6E8E2 /* StackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62952C970E1F00D6E8E2 /* StackView.swift */; };
 		AF8F62982C97372500D6E8E2 /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62972C97372500D6E8E2 /* FloatingButton.swift */; };
+		AF8F629C2C97C74E00D6E8E2 /* Photo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F629B2C97C74E00D6E8E2 /* Photo.swift */; };
+		AF8F62A02C97F32E00D6E8E2 /* GalleryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F629F2C97F32E00D6E8E2 /* GalleryViewModel.swift */; };
+		AF8F62A22C97F38D00D6E8E2 /* PhotoThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A12C97F38D00D6E8E2 /* PhotoThumbnail.swift */; };
+		AF8F62A42C97F67A00D6E8E2 /* GalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A32C97F67A00D6E8E2 /* GalleryView.swift */; };
+		AF8F62A62C98123600D6E8E2 /* ImageLoadingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A52C98123600D6E8E2 /* ImageLoadingService.swift */; };
+		AF8F62A82C98181E00D6E8E2 /* SelectedPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8F62A72C98181E00D6E8E2 /* SelectedPhotoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +57,12 @@
 		AF8F62922C97083C00D6E8E2 /* ColorInfoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorInfoCardView.swift; sourceTree = "<group>"; };
 		AF8F62952C970E1F00D6E8E2 /* StackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackView.swift; sourceTree = "<group>"; };
 		AF8F62972C97372500D6E8E2 /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
+		AF8F629B2C97C74E00D6E8E2 /* Photo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.swift; sourceTree = "<group>"; };
+		AF8F629F2C97F32E00D6E8E2 /* GalleryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryViewModel.swift; sourceTree = "<group>"; };
+		AF8F62A12C97F38D00D6E8E2 /* PhotoThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoThumbnail.swift; sourceTree = "<group>"; };
+		AF8F62A32C97F67A00D6E8E2 /* GalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryView.swift; sourceTree = "<group>"; };
+		AF8F62A52C98123600D6E8E2 /* ImageLoadingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoadingService.swift; sourceTree = "<group>"; };
+		AF8F62A72C98181E00D6E8E2 /* SelectedPhotoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPhotoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +127,7 @@
 		AF8F62692C91525400D6E8E2 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				AF8F629A2C97C70C00D6E8E2 /* GalleryView */,
 				AF8F62952C970E1F00D6E8E2 /* StackView.swift */,
 				AF8F628D2C97043500D6E8E2 /* Component */,
 				AF8F625B2C9135AA00D6E8E2 /* ContentView.swift */,
@@ -169,6 +182,19 @@
 				AF8F62972C97372500D6E8E2 /* FloatingButton.swift */,
 			);
 			path = Component;
+			sourceTree = "<group>";
+		};
+		AF8F629A2C97C70C00D6E8E2 /* GalleryView */ = {
+			isa = PBXGroup;
+			children = (
+				AF8F629B2C97C74E00D6E8E2 /* Photo.swift */,
+				AF8F629F2C97F32E00D6E8E2 /* GalleryViewModel.swift */,
+				AF8F62A12C97F38D00D6E8E2 /* PhotoThumbnail.swift */,
+				AF8F62A32C97F67A00D6E8E2 /* GalleryView.swift */,
+				AF8F62A52C98123600D6E8E2 /* ImageLoadingService.swift */,
+				AF8F62A72C98181E00D6E8E2 /* SelectedPhotoView.swift */,
+			);
+			path = GalleryView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -241,23 +267,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF8F62752C9165EA00D6E8E2 /* ObjectDetectionManager.swift in Sources */,
+				AF8F62A02C97F32E00D6E8E2 /* GalleryViewModel.swift in Sources */,
 				AF8F626F2C91544300D6E8E2 /* ColorInfo.swift in Sources */,
 				AF8F62882C96CDF800D6E8E2 /* ImageData.swift in Sources */,
 				AF8F62792C95E35900D6E8E2 /* ColorExtractionManager.swift in Sources */,
 				AF8F625C2C9135AA00D6E8E2 /* ContentView.swift in Sources */,
+				AF8F629C2C97C74E00D6E8E2 /* Photo.swift in Sources */,
 				AF8F625A2C9135AA00D6E8E2 /* PaletteMApp.swift in Sources */,
 				AF8F627E2C95EA1B00D6E8E2 /* Color+Extensions.swift in Sources */,
+				AF8F62A22C97F38D00D6E8E2 /* PhotoThumbnail.swift in Sources */,
 				AF8F62772C93C27D00D6E8E2 /* YOLOv3Int8LUT.mlmodel in Sources */,
 				AF8F62962C970E1F00D6E8E2 /* StackView.swift in Sources */,
 				AF8F62912C9707E500D6E8E2 /* ColorInfoView.swift in Sources */,
+				AF8F62A82C98181E00D6E8E2 /* SelectedPhotoView.swift in Sources */,
 				AF8F62802C95EAA500D6E8E2 /* UIColor+Extensions.swift in Sources */,
 				AF8F627C2C95E3C500D6E8E2 /* UIImage+Extensions.swift in Sources */,
 				AF8F62732C9163CF00D6E8E2 /* DetectedObject.swift in Sources */,
+				AF8F62A42C97F67A00D6E8E2 /* GalleryView.swift in Sources */,
 				AF8F62932C97083C00D6E8E2 /* ColorInfoCardView.swift in Sources */,
 				AF8F62712C91551700D6E8E2 /* ColorExtractorViewModel.swift in Sources */,
 				AF8F628A2C96D31200D6E8E2 /* PreviewContainer.swift in Sources */,
 				AF8F628F2C97048C00D6E8E2 /* FlipCard.swift in Sources */,
 				AF8F62842C96B0A900D6E8E2 /* PhotoFrameView.swift in Sources */,
+				AF8F62A62C98123600D6E8E2 /* ImageLoadingService.swift in Sources */,
 				AF8F62982C97372500D6E8E2 /* FloatingButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -395,6 +427,7 @@
 				DEVELOPMENT_TEAM = ZWTS2P7AH7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진에 접근하기 위해 귀하의 허가가 필요합니다. 앱에서 사용할 사진을 선택할 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -428,6 +461,7 @@
 				DEVELOPMENT_TEAM = ZWTS2P7AH7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진에 접근하기 위해 귀하의 허가가 필요합니다. 앱에서 사용할 사진을 선택할 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
+++ b/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
@@ -63,4 +63,7 @@ extension Color: Codable {
     static let lightPeach = Color(red: 1.0, green: 0.878, blue: 0.675)
     static let mintGreen = Color(red: 0.741, green: 0.918, blue: 0.882)
     static let skyBlue = Color(red: 0.686, green: 0.843, blue: 0.953)
+    static let lightBeige = Color(red: 0.96, green: 0.87, blue: 0.70)
+    static let darkBeige = Color(red: 0.90, green: 0.75, blue: 0.50)
+
 }

--- a/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
+++ b/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
@@ -52,4 +52,21 @@ extension Color: Codable {
         let uiColor = UIColor(self)
         return uiColor.toRGBString()
     }
+    
+    static let pastelRed = Color(red: 255/255, green: 209/255, blue: 220/255)
+    static let pastelGreen = Color(red: 203/255, green: 241/255, blue: 203/255)
+    static let pastelBlue = Color(red: 173/255, green: 216/255, blue: 230/255)
+    static let pastelYellow = Color(red: 253/255, green: 253/255, blue: 150/255)
+    static let softCharcoal = Color(red: 54/255, green: 69/255, blue: 79/255)
+    // 크림색 오프화이트
+       static let creamyWhite = Color(red: 253/255, green: 252/255, blue: 245/255)
+       
+       // 따뜻한 오프화이트
+       static let warmOffWhite = Color(red: 255/255, green: 253/255, blue: 248/255)
+       
+       // 차가운 오프화이트
+       static let coolOffWhite = Color(red: 248/255, green: 250/255, blue: 252/255)
+       
+       // 매우 연한 베이지
+       static let softBeige = Color(red: 245/255, green: 245/255, blue: 237/255)
 }

--- a/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
+++ b/PaletteM/PaletteM/Model/Helper/Color+Extensions.swift
@@ -58,15 +58,9 @@ extension Color: Codable {
     static let pastelBlue = Color(red: 173/255, green: 216/255, blue: 230/255)
     static let pastelYellow = Color(red: 253/255, green: 253/255, blue: 150/255)
     static let softCharcoal = Color(red: 54/255, green: 69/255, blue: 79/255)
-    // 크림색 오프화이트
-       static let creamyWhite = Color(red: 253/255, green: 252/255, blue: 245/255)
-       
-       // 따뜻한 오프화이트
-       static let warmOffWhite = Color(red: 255/255, green: 253/255, blue: 248/255)
-       
-       // 차가운 오프화이트
-       static let coolOffWhite = Color(red: 248/255, green: 250/255, blue: 252/255)
-       
-       // 매우 연한 베이지
-       static let softBeige = Color(red: 245/255, green: 245/255, blue: 237/255)
+    static let softBeige = Color(red: 245/255, green: 245/255, blue: 237/255)
+    static let softPink = Color(red: 1.0, green: 0.714, blue: 0.757)
+    static let lightPeach = Color(red: 1.0, green: 0.878, blue: 0.675)
+    static let mintGreen = Color(red: 0.741, green: 0.918, blue: 0.882)
+    static let skyBlue = Color(red: 0.686, green: 0.843, blue: 0.953)
 }

--- a/PaletteM/PaletteM/Model/SwiftData/ImageData.swift
+++ b/PaletteM/PaletteM/Model/SwiftData/ImageData.swift
@@ -13,11 +13,13 @@ class ImageData {
     var id: UUID
     var imageData: Data
     var colorInfos: [ColorInfo]
+    var createdAt: Date
     
     init(id: UUID = UUID(), imageData: Data, colorInfos: [ColorInfo] = []) {
         self.id = id
         self.imageData = imageData
         self.colorInfos = colorInfos
+        self.createdAt = Date() 
     }
 }
 

--- a/PaletteM/PaletteM/PaletteMApp.swift
+++ b/PaletteM/PaletteM/PaletteMApp.swift
@@ -10,10 +10,14 @@ import SwiftData
 
 @main
 struct PaletteMApp: App {
+    
+    @StateObject var galleryVm = GalleryViewModel()
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+        .environmentObject(galleryVm)
         .modelContainer(for: ImageData.self)
     }
 }

--- a/PaletteM/PaletteM/PaletteMApp.swift
+++ b/PaletteM/PaletteM/PaletteMApp.swift
@@ -12,12 +12,14 @@ import SwiftData
 struct PaletteMApp: App {
     
     @StateObject var galleryVm = GalleryViewModel()
+    @StateObject var colorExtractor = ColorExtractorViewModel()
     
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
         .environmentObject(galleryVm)
+        .environmentObject(colorExtractor)
         .modelContainer(for: ImageData.self)
     }
 }

--- a/PaletteM/PaletteM/View/Component/FlipCard.swift
+++ b/PaletteM/PaletteM/View/Component/FlipCard.swift
@@ -30,7 +30,7 @@ struct FlipCard: View {
         .clipShape(RoundedRectangle(cornerRadius: 15))
         .shadow(color: .gray.opacity(0.2), radius: 5, x: 5, y: 5)
         .shadow(color: .gray.opacity(0.15), radius: 5, x: -2, y: -3)
-        .shadow(color: .white.opacity(0.3), radius: 2)
+        .shadow(color: .white.opacity(0.5), radius: 5)
         .frame(maxWidth: 320)
         .frame(maxHeight: 550)
         .padding(.vertical)

--- a/PaletteM/PaletteM/View/Component/FlipCard.swift
+++ b/PaletteM/PaletteM/View/Component/FlipCard.swift
@@ -30,7 +30,7 @@ struct FlipCard: View {
         .clipShape(RoundedRectangle(cornerRadius: 15))
         .shadow(color: .gray.opacity(0.2), radius: 5, x: 5, y: 5)
         .shadow(color: .gray.opacity(0.15), radius: 5, x: -2, y: -3)
-        .shadow(color: .white.opacity(0.5), radius: 5)
+        .shadow(color: .white, radius: 1)
         .frame(maxWidth: 320)
         .frame(maxHeight: 550)
         .padding(.vertical)

--- a/PaletteM/PaletteM/View/Component/FloatingButton.swift
+++ b/PaletteM/PaletteM/View/Component/FloatingButton.swift
@@ -21,6 +21,9 @@ struct FloatingButton<Label: View>: View {
     }
     
     @State private var isExpanded: Bool = false
+    @State private var dragLocation: CGPoint = .zero
+    @State private var selectedAction: FloatingAction?
+    @GestureState private var isDragging: Bool = false
     
     var body: some View {
         Button{
@@ -31,6 +34,25 @@ struct FloatingButton<Label: View>: View {
                 .contentShape(.rect)
         }
         .buttonStyle(NoAnimationButtonStyle())
+        .gesture(LongPressGesture(minimumDuration: 0.3)
+            .onEnded{ _ in
+                isExpanded = true
+            }.sequenced(before: DragGesture().updating($isDragging, body: { _, out, _ in
+                    out = true
+                }).onChanged{ value in
+                    guard isExpanded else { return }
+                    dragLocation = value.location
+                }).onEnded({ _ in
+                    Task{
+                        if let selectedAction {
+                            isExpanded = false
+                            selectedAction.action()
+                        }
+                        selectedAction = nil
+                        dragLocation = .zero
+                    }
+                })
+        )
         .background{
             ZStack{
                 ForEach(actions) { action in
@@ -40,6 +62,7 @@ struct FloatingButton<Label: View>: View {
             }
             .frame(width: buttonSize, height: buttonSize)
         }
+        .coordinateSpace(name: "FLOATING VIEW")
         .animation(.snappy(duration: 0.4, extraBounce: 0), value: isExpanded )
     }
     
@@ -64,6 +87,31 @@ struct FloatingButton<Label: View>: View {
         })
         .buttonStyle(PressableButtonStyle())
         .disabled(!isExpanded)
+        .animation(.snappy(duration: 0.3, extraBounce: 0)) { content in
+            content
+                .scaleEffect(selectedAction?.id == action.id ? 1.15 :1 )
+            
+        }
+        .background {
+            GeometryReader{
+                let rect = $0.frame(in: .named("FLOATING VIEW"))
+                Color.clear
+                    .onChange(of: dragLocation) { oldValue, newValue in
+                        if isExpanded && isDragging {
+                            /// Checking if the drag location is inside any action's rect
+                            if rect.contains(newValue){
+                                /// User is Pressing on this Action
+                                selectedAction = action
+                            } else {
+                                /// Checking if it's gone out of the rect
+                                if selectedAction?.id == action.id && !rect.contains(newValue){
+                                    selectedAction = nil
+                                }
+                            }
+                        }
+                    }
+            }
+        }
         .rotationEffect(.init(degrees: progress(action) * -180))
         .offset(x: isExpanded ? -offset / 2 : 0 )
         .rotationEffect(.init(degrees: progress(action) * 180))

--- a/PaletteM/PaletteM/View/Component/FloatingButton.swift
+++ b/PaletteM/PaletteM/View/Component/FloatingButton.swift
@@ -1,0 +1,119 @@
+//
+//  AddButton.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+
+/// CustomButton
+struct FloatingButton<Label: View>: View {
+    var buttonSize: CGFloat
+    /// Actions
+    var actions: [FloatingAction]
+    var label: (Bool) -> Label
+    
+    init(buttonSize: CGFloat = 60, @FloationActionBuilder actions: @escaping () -> [FloatingAction], @ViewBuilder label: @escaping (Bool) -> Label) {
+        self.buttonSize = buttonSize
+        self.actions = actions()
+        self.label = label
+    }
+    
+    @State private var isExpanded: Bool = false
+    
+    var body: some View {
+        Button{
+            isExpanded.toggle()
+        }label: {
+            label(isExpanded)
+                .frame(width: buttonSize, height: buttonSize)
+                .contentShape(.rect)
+        }
+        .buttonStyle(NoAnimationButtonStyle())
+        .background{
+            ZStack{
+                ForEach(actions) { action in
+                    
+                    ActionView(action)
+                }
+            }
+            .frame(width: buttonSize, height: buttonSize)
+        }
+        .animation(.snappy(duration: 0.4, extraBounce: 0), value: isExpanded )
+    }
+    
+    @ViewBuilder
+    func ActionView(_ action: FloatingAction) -> some View {
+        
+        Button(action: {
+            action.action()
+            isExpanded = false
+            
+        }, label: {
+            Image(systemName: action.symbol)
+                .font(action.font)
+                .foregroundColor(action.tint)
+                .frame(width: buttonSize, height: buttonSize)
+                .background(action.background, in: .circle)
+                .padding()
+                .contentShape(.circle)
+                .shadow(color: .white.opacity(0.6), radius: 1)
+                .shadow(color: .white.opacity(0.8), radius: 20)
+               
+        })
+        .buttonStyle(PressableButtonStyle())
+        .disabled(!isExpanded)
+        .rotationEffect(.init(degrees: progress(action) * -180))
+        .offset(x: isExpanded ? -offset / 2 : 0 )
+        .rotationEffect(.init(degrees: progress(action) * 180))
+        
+            
+    }
+    
+    private var offset: CGFloat {
+        let buttonSize = buttonSize - 10
+        return Double(actions.count) * (actions.count == 1 ? buttonSize * 2 : (actions.count == 2 ? buttonSize * 1.25 : buttonSize))
+    }
+    
+    private func progress(_ action: FloatingAction) -> CGFloat {
+        let index = CGFloat(actions.firstIndex(where: {$0.id == action.id}) ?? 0)
+        return actions.count == 1 ? 1 : (index / CGFloat(actions.count - 1))
+    }
+}
+
+fileprivate struct NoAnimationButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+    }
+}
+
+fileprivate struct PressableButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.9 : 1)
+            .animation(.snappy(duration: 0.3), value: configuration.isPressed)
+    }
+}
+
+struct FloatingAction: Identifiable {
+    private(set) var id: UUID = .init()
+    var symbol: String
+    var font: Font = .title
+    var tint: Color = .softBeige
+    var background: Color = .black
+    var action: () -> ()
+}
+
+/// Swift's result builders allow you to construct a result using 'build blocks' lined up after each other, This is a very basic example of the usage of result builders, Check out about result builders for more complex usages
+/// SwiftUI View like Builder to get array of actions using ResultBuilder
+@resultBuilder
+struct FloationActionBuilder {
+    static func buildBlock( _ components: FloatingAction...) -> [FloatingAction] {
+        components.compactMap({$0})
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/PaletteM/PaletteM/View/ContentView.swift
+++ b/PaletteM/PaletteM/View/ContentView.swift
@@ -14,12 +14,62 @@ struct ContentView: View {
     var body: some View {
         
         NavigationStack{
-            
-            VStack{
-                StackView()
+            ZStack{
+                
+                LinearGradient(
+                    gradient: Gradient(colors: [
+                        Color(red: 1.0, green: 0.714, blue: 0.757),
+                        Color(red: 1.0, green: 0.878, blue: 0.675),
+                        Color(red: 0.741, green: 0.918, blue: 0.882),
+                        Color(red: 0.686, green: 0.843, blue: 0.953)
+                    ]),
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+                
+                VStack(spacing: 8){
+                    Text("PaletteM")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .foregroundStyle(Color.softCharcoal)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 20)
+                        .padding(.top, 24)
                     
+                    StackView()
+                    
+                }
+                .padding(.top, 30)
+                .ignoresSafeArea()
             }
-            .navigationTitle("PaletteM")
+        }
+        .overlay(alignment: .bottom){
+            FloatingButton{
+                FloatingAction(symbol: "camera", background: .pastelRed) {
+                    
+                }
+                FloatingAction(symbol: "photo", background: .pastelGreen){
+                    
+                }
+                FloatingAction(symbol: "square.and.arrow.up", background: .pastelBlue ) {
+                    
+                }
+            } label: { isExpanded in
+                Image(systemName: "plus")
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundStyle(Color.softBeige)
+                    .rotationEffect(.init(degrees: isExpanded ? 45 : 0))
+                    .scaleEffect(1.02)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.pastelYellow, in: .circle)
+                    /// Scaling Effect When Expaned
+                    .scaleEffect(isExpanded ? 0.9 : 1)
+            }
+         
+
+            
         }
         
     }

--- a/PaletteM/PaletteM/View/ContentView.swift
+++ b/PaletteM/PaletteM/View/ContentView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 // MARK: - View
 struct ContentView: View {
-    @StateObject private var viewModel = ColorExtractorViewModel()
+    
+    @State private var isShowSelectGallery = false
     
     var body: some View {
         
@@ -43,6 +44,9 @@ struct ContentView: View {
                 .padding(.top, 30)
                 .ignoresSafeArea()
             }
+            .fullScreenCover(isPresented: $isShowSelectGallery) {
+                GalleryView(isShowSelectGallery: $isShowSelectGallery)
+            }
         }
         .overlay(alignment: .bottom){
             FloatingButton{
@@ -50,7 +54,7 @@ struct ContentView: View {
                     
                 }
                 FloatingAction(symbol: "photo", background: .pastelGreen){
-                    
+                    isShowSelectGallery = true 
                 }
                 FloatingAction(symbol: "square.and.arrow.up", background: .pastelBlue ) {
                     
@@ -67,8 +71,6 @@ struct ContentView: View {
                     /// Scaling Effect When Expaned
                     .scaleEffect(isExpanded ? 0.9 : 1)
             }
-         
-
             
         }
         

--- a/PaletteM/PaletteM/View/ContentView.swift
+++ b/PaletteM/PaletteM/View/ContentView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 // MARK: - View
 struct ContentView: View {
     @StateObject private var viewModel = ColorExtractorViewModel()
-    @State private var showingAlert = false
     
     var body: some View {
         

--- a/PaletteM/PaletteM/View/ContentView.swift
+++ b/PaletteM/PaletteM/View/ContentView.swift
@@ -19,10 +19,7 @@ struct ContentView: View {
                 
                 LinearGradient(
                     gradient: Gradient(colors: [
-                        Color(red: 1.0, green: 0.714, blue: 0.757),
-                        Color(red: 1.0, green: 0.878, blue: 0.675),
-                        Color(red: 0.741, green: 0.918, blue: 0.882),
-                        Color(red: 0.686, green: 0.843, blue: 0.953)
+                        .softPink, .lightPeach, .mintGreen, .skyBlue
                     ]),
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing

--- a/PaletteM/PaletteM/View/GalleryView/GalleryView.swift
+++ b/PaletteM/PaletteM/View/GalleryView/GalleryView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct GalleryView: View {
     
     @EnvironmentObject var viewModel: GalleryViewModel
+    @EnvironmentObject var colorExtractor: ColorExtractorViewModel
+    @State private var path: [NavigationDestination] = []
     @Binding var isShowSelectGallery: Bool
     
     let columns = [
@@ -19,7 +21,7 @@ struct GalleryView: View {
     ]
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             VStack(spacing: 0) {
                 
                 SelectedPhotoView(viewModel: viewModel, size: UIScreen.main.bounds.width)
@@ -43,20 +45,15 @@ struct GalleryView: View {
                         }
                     }
                 }
+            }
+            .navigationDestination(for: NavigationDestination.self) { destination in
+                switch  destination {
+                case .resultView:
+                    ResultView(path: $path, isShowSelectGallery: $isShowSelectGallery)
+                }
                 
             }
             .toolbar {
-                ToolbarItem(placement:.topBarTrailing) {
-                    
-                    Button(action: {
-                        print("Selected photo: \(viewModel.selectedPhoto?.id ?? "None")")
-                    }, label: {
-                        Text("선택")
-                            .fontWeight(.semibold)
-                    })
-                    .disabled(viewModel.selectedPhoto == nil)
-                 
-                }
                 
                 ToolbarItem(placement: .topBarLeading) {
                     Button(action: {
@@ -67,8 +64,23 @@ struct GalleryView: View {
                             .foregroundStyle(Color.softBeige)
                     })
                 }
+                
+                ToolbarItem(placement:.topBarTrailing) {
+                    
+                    Button(action: {
+                        if let selectedImage = viewModel.selectedImage{
+                            colorExtractor.selectImage(selectedImage)
+                        }
+                        path.append(.resultView)
+                        
+                    }, label: {
+                        Text("선택")
+                            .fontWeight(.semibold)
+                    })
+                    .disabled(viewModel.selectedPhoto == nil)
+                 
+                }
             }
-            
         }
         .preferredColorScheme(.dark)
         .ignoresSafeArea()
@@ -76,6 +88,9 @@ struct GalleryView: View {
             if viewModel.photos.isEmpty {
                 viewModel.fetchPhotos()
             }
+        }
+        .onDisappear{
+            viewModel.clear()  
         }
     }
 }

--- a/PaletteM/PaletteM/View/GalleryView/GalleryView.swift
+++ b/PaletteM/PaletteM/View/GalleryView/GalleryView.swift
@@ -1,0 +1,96 @@
+//
+//  GalleryView.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+
+struct GalleryView: View {
+    
+    @EnvironmentObject var viewModel: GalleryViewModel
+    @Binding var isShowSelectGallery: Bool
+    
+    let columns = [
+        GridItem(.flexible(), spacing: 2),
+        GridItem(.flexible(), spacing: 2),
+        GridItem(.flexible(), spacing: 2)
+    ]
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                
+                SelectedPhotoView(viewModel: viewModel, size: UIScreen.main.bounds.width)
+                
+                Rectangle()
+                    .fill(.background)
+                    .frame(maxHeight: 12)
+                    .padding(.vertical, 4)
+                
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 2) {
+                        ForEach(viewModel.photos) { photo in
+                            PhotoThumbnail(photo: photo, size: UIScreen.main.bounds.width / 3 - 1)
+                                .overlay(
+                                    Color.softBeige.opacity(viewModel.selectedPhoto?.id == photo.id ? 0.3 : 0)
+                                )
+                                .contentShape(.rect)
+                                .onTapGesture {
+                                    viewModel.selectPhoto(photo)
+                                }
+                        }
+                    }
+                }
+                
+            }
+            .toolbar {
+                ToolbarItem(placement:.topBarTrailing) {
+                    
+                    Button(action: {
+                        print("Selected photo: \(viewModel.selectedPhoto?.id ?? "None")")
+                    }, label: {
+                        Text("선택")
+                            .fontWeight(.semibold)
+                    })
+                    .disabled(viewModel.selectedPhoto == nil)
+                 
+                }
+                
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: {
+                        isShowSelectGallery = false 
+                    }, label: {
+                        Image(systemName: "xmark")
+                            .fontWeight(.semibold)
+                            .foregroundStyle(Color.softBeige)
+                    })
+                }
+            }
+            
+        }
+        .preferredColorScheme(.dark)
+        .ignoresSafeArea()
+        .onAppear {
+            if viewModel.photos.isEmpty {
+                viewModel.fetchPhotos()
+            }
+        }
+    }
+}
+
+struct GalleryView_Previews: PreviewProvider {
+    static var previews: some View {
+        GalleryView(isShowSelectGallery: .constant(true))
+    }
+    
+    static func mockGalleryViewModel() -> GalleryViewModel {
+        let viewModel = GalleryViewModel()
+        viewModel.photos = (1...16).map { _ in
+            Photo(image: UIImage(named: "sample_person2")!)
+        }
+        viewModel.selectedPhoto = viewModel.photos.first
+        return viewModel
+    }
+}

--- a/PaletteM/PaletteM/View/GalleryView/GalleryViewModel.swift
+++ b/PaletteM/PaletteM/View/GalleryView/GalleryViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  GalleryViewModel.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import PhotosUI
+
+class GalleryViewModel: ObservableObject {
+    
+    @Published var photos: [Photo] = []
+    @Published var selectedPhoto: Photo?
+    @Published var selectedImage: UIImage?
+    private let imageLoadingService = ImageLoadingService.shared
+    
+    func fetchPhotos() {
+        let fetchOptions = PHFetchOptions()
+        fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        let assets = PHAsset.fetchAssets(with: .image, options: fetchOptions)
+        
+        photos = assets.objects(at: IndexSet(0..<assets.count)).map { Photo(asset: $0) }
+        
+        if let firstPhoto = photos.first {
+            selectedPhoto = firstPhoto
+            loadSelectedImage()
+        }
+    }
+    
+    func selectPhoto(_ photo: Photo) {
+        self.selectedPhoto = photo
+        loadSelectedImage()
+    }
+    
+    private func loadSelectedImage() {
+        guard let photo = selectedPhoto else {
+            selectedImage = nil
+            return
+        }
+        if let asset = photo.asset{
+            imageLoadingService.loadImage(for: asset, size: PHImageManagerMaximumSize) { [weak self] image in
+                DispatchQueue.main.async {
+                    self?.selectedImage = image
+                }
+            }
+        }
+    }
+}

--- a/PaletteM/PaletteM/View/GalleryView/GalleryViewModel.swift
+++ b/PaletteM/PaletteM/View/GalleryView/GalleryViewModel.swift
@@ -27,6 +27,12 @@ class GalleryViewModel: ObservableObject {
         }
     }
     
+    func clear(){
+        photos = []
+        selectedImage = nil
+        selectedImage = nil 
+    }
+    
     func selectPhoto(_ photo: Photo) {
         self.selectedPhoto = photo
         loadSelectedImage()

--- a/PaletteM/PaletteM/View/GalleryView/ImageLoadingService.swift
+++ b/PaletteM/PaletteM/View/GalleryView/ImageLoadingService.swift
@@ -1,0 +1,42 @@
+//
+//  ImageLoadingService.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import PhotosUI
+
+class ImageLoadingService {
+    static let shared = ImageLoadingService()
+    private let imageManager = PHImageManager.default()
+    private let cache = NSCache<NSString, UIImage>()
+    
+    private init() {}
+    
+    func loadImage(for asset: PHAsset, size: CGSize, completion: @escaping (UIImage?) -> Void) {
+        let cacheKey = "\(asset.localIdentifier)_\(Int(size.width))x\(Int(size.height))"
+        
+        if let cachedImage = cache.object(forKey: cacheKey as NSString) {
+            completion(cachedImage)
+            return
+        }
+        
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .opportunistic
+        options.resizeMode = .fast
+        
+        imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: options) { [weak self] image, _ in
+            if let image = image {
+                self?.cache.setObject(image, forKey: cacheKey as NSString)
+                DispatchQueue.main.async {
+                    completion(image)
+                }
+            } else {
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
+            }
+        }
+    }
+}

--- a/PaletteM/PaletteM/View/GalleryView/Photo.swift
+++ b/PaletteM/PaletteM/View/GalleryView/Photo.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct Photo: Identifiable {
+    let id: String
+    let asset: PHAsset?
+    let image: UIImage?
+    
+    init(asset: PHAsset) {
+        self.id = asset.localIdentifier
+        self.asset = asset
+        self.image = nil
+    }
+    
+    init(image: UIImage) {
+        self.id = UUID().uuidString
+        self.asset = nil
+        self.image = image
+    }
+}

--- a/PaletteM/PaletteM/View/GalleryView/PhotoThumbnail.swift
+++ b/PaletteM/PaletteM/View/GalleryView/PhotoThumbnail.swift
@@ -1,0 +1,39 @@
+//
+//  PhotoThumbnail.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import PhotosUI
+import SwiftUI
+
+struct PhotoThumbnail: View {
+    let photo: Photo
+    @State private var image: UIImage?
+    let size: CGFloat
+    
+    var body: some View {
+        Group {
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                ProgressView()
+            }
+        }
+        .frame(width: size, height: size)
+        .clipped()
+        .onAppear(perform: loadImage)
+        
+    }
+    
+    private func loadImage() {
+        if let asset = photo.asset {
+            ImageLoadingService.shared.loadImage(for: asset, size: CGSize(width: size, height: size)) { loadedImage in
+                self.image = loadedImage
+            }
+        }
+    }
+}

--- a/PaletteM/PaletteM/View/GalleryView/SelectedPhotoView.swift
+++ b/PaletteM/PaletteM/View/GalleryView/SelectedPhotoView.swift
@@ -1,0 +1,29 @@
+//
+//  SelectedPhotoView.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+
+struct SelectedPhotoView: View {
+    @ObservedObject var viewModel: GalleryViewModel
+    let size : CGFloat
+    
+    var body: some View {
+        Group {
+            if let image = viewModel.selectedImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else if viewModel.selectedPhoto != nil {
+                ProgressView()
+            } else {
+                Text("선택된 사진이 없습니다.")
+            }
+        }
+        .frame(width: size, height: size)
+        .clipped()
+    }
+}

--- a/PaletteM/PaletteM/View/LoadingFlipCard.swift
+++ b/PaletteM/PaletteM/View/LoadingFlipCard.swift
@@ -1,0 +1,40 @@
+//
+//  LoadingFlipCard.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+
+// MARK: - 회전하는 카드 애니메이션 뷰
+struct RotatingCardView: View {
+    @State private var rotationAngle: Double = 0
+    let image: UIImage
+    
+    var body: some View {
+        
+        ZStack{
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.softBeige) // 카드 색상
+  
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .cornerRadius(20) // 이미지도 카드 모서리에 맞게 둥글게
+        }
+        .frame(width: 210, height: 390)
+        .frame(maxWidth: 320)
+        .frame(maxHeight: 550)
+        .rotation3DEffect(
+            .degrees(rotationAngle), // 각도에 따라 회전
+            axis: (x: 0, y: 1, z: 0) // Y축을 기준으로 회전
+        )
+        .onAppear {
+            withAnimation(Animation.linear(duration: 2).repeatForever(autoreverses: false)) {
+                rotationAngle = 360 // 360도 회전
+            }
+        }
+        
+    }
+}

--- a/PaletteM/PaletteM/View/NavigationDestination.swift
+++ b/PaletteM/PaletteM/View/NavigationDestination.swift
@@ -1,0 +1,12 @@
+//
+//  NavigationDestination.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+
+enum NavigationDestination: Hashable {
+    case resultView
+}

--- a/PaletteM/PaletteM/View/ResultView.swift
+++ b/PaletteM/PaletteM/View/ResultView.swift
@@ -1,0 +1,100 @@
+//
+//  ResultView.swift
+//  PaletteM
+//
+//  Created by 이종선 on 9/16/24.
+//
+
+import SwiftUI
+
+struct ResultView: View {
+    
+    @Environment(\.modelContext) private var context
+    @EnvironmentObject var vm: ColorExtractorViewModel
+    @Binding var path: [NavigationDestination]
+    @Binding var isShowSelectGallery: Bool
+    
+    
+    var body: some View {
+        
+        ZStack{
+            LinearGradient(
+                gradient: Gradient(colors: [.lightBeige, .darkBeige]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+            
+            VStack {
+                // 이미지가 선택되었고 처리 완료된 경우 보여줌
+                // MARK: 선택 이미지로 변경
+                if let image = vm.selectedImage, !vm.distinctColors.isEmpty  {
+                     
+                    FlipCard(image: image, colors: vm.distinctColors)
+                
+                } else if (vm.selectedImage != nil && vm.isProcessing) || (vm.selectedImage != nil && vm.distinctColors.isEmpty) {
+                    // 처리 중일 때는 ProgressView 표시
+                    if let selectedImage = vm.selectedImage{
+                        RotatingCardView(image: selectedImage) // 계속 회전하는 카드 애니메이션
+                    }
+                   
+                        
+                    
+                } else {
+                    // 선택된 이미지가 없을 때 메시지 표시
+                    Text("No image selected.")
+                        .foregroundColor(.gray)
+                }
+            }
+        }
+        .onDisappear{
+            vm.resetImage()
+        }
+        .navigationBarBackButtonHidden()
+        .toolbar{
+            
+            ToolbarItem(placement: .topBarLeading) {
+                Button{
+                    path.removeAll()
+                } label: {
+                    HStack {
+                        Image(systemName: "chevron.left")
+                        Text("뒤로")
+                    }
+                    .fontWeight(.semibold)
+                }
+                .disabled(vm.isProcessing)
+            }
+            
+            
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    save()
+                    isShowSelectGallery = false
+                } label: {
+                    Text("저장")
+                        .fontWeight(.semibold)
+                }
+                .disabled(vm.isProcessing)
+                
+            }
+        }
+        .tint(.softCharcoal)
+    }
+    
+    func save(){
+        if let selectedImage = vm.selectedImage {
+            guard let imageData = selectedImage.jpegData(compressionQuality: 1.0) else {
+                return
+            }
+            let card = ImageData(imageData: imageData, colorInfos: vm.distinctColors)
+            context.insert(card)
+            do {
+                try context.save()
+                print("Image saved successfully")
+            } catch {
+                print("Failed to save image: \(error)")
+            }
+        }
+    }
+}

--- a/PaletteM/PaletteM/View/StackView.swift
+++ b/PaletteM/PaletteM/View/StackView.swift
@@ -13,9 +13,7 @@ struct StackView: View {
     // View Properties
     @State private var isRotationEnabled: Bool = true
     @State private var showsIndicator: Bool = false
-    
-    @Query private var items: [ImageData]
-    @Environment(\.modelContext) private var context
+    @Query(sort: \ImageData.createdAt, order: .reverse) private var items: [ImageData]
     
     var body: some View {
         NavigationStack{

--- a/PaletteM/PaletteM/ViewModel/ColorExtractorViewModel.swift
+++ b/PaletteM/PaletteM/ViewModel/ColorExtractorViewModel.swift
@@ -29,7 +29,6 @@ class ColorExtractorViewModel: ObservableObject {
     
     
     /// 이미지 선택 메서드
-    //MARK: 이미지 선택 로직과 선택된 이미지를 실제로 분석처리를 요청하는 로직과 분리 필요 
     func selectImage(_ image: UIImage) {
         selectedImage = image
         detectObjects(in: image)
@@ -42,6 +41,7 @@ class ColorExtractorViewModel: ObservableObject {
         detectedObjects = []
         detectionError = nil
         imageWithDetectedObjects = nil
+        distinctColors = []
         isProcessing = false
         
     }
@@ -56,7 +56,7 @@ class ColorExtractorViewModel: ObservableObject {
                 case .success(let objects):
                     self?.detectedObjects = objects
                     // MARK: 객체가 감지가 완료된 시점이후 박스 표시
-                    self?.drawDetectedObjectsOnImage()
+                    //self?.drawDetectedObjectsOnImage()
                     
                     // 객체가 감지가 완료된 이후에 색생 추출을 수행
                     self?.extractColors(from: image)
@@ -68,14 +68,12 @@ class ColorExtractorViewModel: ObservableObject {
                     // 객체가 감지에 실패해도 색상 추출을 시도
                     self?.extractColors(from: image)
                 }
-                self?.isProcessing = false
             }
         }
     }
     
     /// 색상 추출 프로세스 구현
     private func extractColors(from image: UIImage) {
-        isProcessing = true
         
         // 레이블별 가중치를 정의합니다.
         let labelWeights: [String: Double] = [
@@ -85,12 +83,12 @@ class ColorExtractorViewModel: ObservableObject {
         
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
-            let colors = self.colorExtractionManager.extractColors(from: image, detectedObjects: self.detectedObjects, labelWeights: labelWeights)
-            
+            let extractedColor = self.colorExtractionManager.extractColors(from: image, detectedObjects: self.detectedObjects, labelWeights: labelWeights)
+            let distinctedColor = self.colorExtractionManager.selectDistinctColors(from: extractedColor)
             DispatchQueue.main.async {
-                self.extractedColors = colors
+                self.extractedColors = extractedColor
                 // 최대 구분색 추가
-                self.distinctColors = self.colorExtractionManager.selectDistinctColors(from: colors)
+                self.distinctColors = distinctedColor
                 self.isProcessing = false
             }
         }


### PR DESCRIPTION
- 갤러리에 접근해서 사진 가져와 갤러리뷰에서 이용자가 자신에 사진첩에 저장되어 있는 사진을 사용할 수 있도록 했습니다 .
- 선택한 사진에 대해 색상 추출 로직을 실행합니다.
- 색상 추출 로직이 실행되는 동안 회전하는 카드 애니메이션을 재생합니다. 
- 색상 추출 로직이 완료되면 완성된 카드를 보여줍니다. 
- 완료 버튼을 누르면 해당 카드를 구성하기 위한 정보 Data, [ColorInfo]를 SwiftData를 이용해 저장합니다. 

